### PR TITLE
Porting over aiohttp from fork

### DIFF
--- a/simc.py
+++ b/simc.py
@@ -231,7 +231,7 @@ async def on_message(message):
                                     return
 
                     if data != 'addon':
-                        api = await check_spec(region, realm, char, api_key)
+                        api = await check_spec(realm, char, api_key)
                         if api == 'HEALING':
                             await bot.send_message(message.channel, 'SimulationCraft does not support healing.')
                             return

--- a/simc.py
+++ b/simc.py
@@ -48,8 +48,8 @@ def check_simc():
     return readversion.readline().rstrip('\n')
 
 
-async def check_spec(realm, char, api_key):
-    url = "https://eu.api.battle.net/wow/character/%s/%s?fields=talents&locale=en_GB&apikey=%s" % (realm, quote(char),
+async def check_spec(region, realm, char, api_key):
+    url = "https://%s.api.battle.net/wow/character/%s/%s?fields=talents&locale=en_GB&apikey=%s" % (region, realm, quote(char),
                                                                                                    api_key)
     async with aiohttp.ClientSession() as session:
         async with session.get(url) as response:
@@ -231,7 +231,7 @@ async def on_message(message):
                                     return
 
                     if data != 'addon':
-                        api = await check_spec(realm, char, api_key)
+                        api = await check_spec(region, realm, char, api_key)
                         if api == 'HEALING':
                             await bot.send_message(message.channel, 'SimulationCraft does not support healing.')
                             return

--- a/simc.py
+++ b/simc.py
@@ -231,7 +231,7 @@ async def on_message(message):
                                     return
 
                     if data != 'addon':
-                        api = await check_spec(region, realm, char, apikey)
+                        api = await check_spec(region, realm, char, api_key)
                         if api == 'HEALING':
                             await bot.send_message(message.channel, 'SimulationCraft does not support healing.')
                             return


### PR DESCRIPTION
this will ensure that the API check is not a blocking request preventing the bot from responding to other requests (like version check)
This isn't such a issue for a bot running on a small server, but having blocking web requests could potentially block the bot until timeout is reached

It will also now stop if the character doesn't exist instead of sending the request to SimC

I haven't tested this commit on this bot myself, but same as last time it's ported over from the fork and should work fine (in theory)